### PR TITLE
Maintain formatting of brew session description

### DIFF
--- a/Brewgr.Web/Views/Shared/_BrewSessionList.cshtml
+++ b/Brewgr.Web/Views/Shared/_BrewSessionList.cshtml
@@ -70,7 +70,7 @@
 			@if (!string.IsNullOrWhiteSpace(brewSession.Summary))
 			{
 				<div class="description">
-					@brewSession.Summary
+					<pre>@brewSession.Summary</pre>
 				</div>
 			}
 		</div>


### PR DESCRIPTION
Currently any line breaks added to a brew session description in edit mode are not being displayed when viewing the session notes.

Before:
![image](https://cloud.githubusercontent.com/assets/557065/17370376/1cb232b2-599c-11e6-9d25-c10d83239662.png)

After:
![image](https://cloud.githubusercontent.com/assets/557065/17370380/253f2b92-599c-11e6-9d98-2f0f2af49f98.png)
